### PR TITLE
fixed a link to the google ML chapter, also added the assets dir in _…

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,7 +19,7 @@ format:
     # - assets/citation.css
     link-external-newwindow: true
     template-partials:
-    - title-block.html
+    - assets/title-block.html
     filters:
     - lightbox
     lightbox:

--- a/chapters/practices.md
+++ b/chapters/practices.md
@@ -833,8 +833,7 @@ See this [N3C Community Note](https://unite.nih.gov/workspace/module/view/latest
 Caton, in his [review of fairness](https://arxiv.org/abs/2010.04053) in machine learning (ML),
 points to 3 phases of analysis: Pre-processing, Processing, and Post-processing.
 We defer other considerations for machine learning, including bias and generalizability,
-to the special topics appendix chapter
-[here](https://docs.google.com/document/d/1YLsu1AWK86b93ak-uHKn5_10PNcxY0dkKEmLH48IQT4/edit?usp=share_link).
+to the [Machine Learning chapter](ml.md).
 
 #### Pre-Processing {#sec-practices-development-analysis-preprocessing}
 


### PR DESCRIPTION
…quarto.yml


This PR does not fix the funky switch to ch 12 headings after the big table, further down.