### PR TITLE
Quarto chapter headers fix, no auto-format markdown on save in RStudio

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,7 +19,7 @@ format:
     # - assets/citation.css
     link-external-newwindow: true
     template-partials:
-    - assets/title-block.html
+    - title-block.html
     filters:
     - lightbox
     lightbox:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,8 +18,8 @@ format:
     - assets/tables.css
     # - assets/citation.css
     link-external-newwindow: true
-    template-partials:
-    - title-block.html
+    # template-partials:
+    # - title-block.html
     filters:
     - lightbox
     lightbox:

--- a/guide-to-n3c.Rproj
+++ b/guide-to-n3c.Rproj
@@ -17,4 +17,4 @@ StripTrailingWhitespace: Yes
 
 UseNativePipeOperator: Yes
 
-MarkdownCanonical: Yes
+MarkdownCanonical: No


### PR DESCRIPTION
I believe this fixes #202 ; I'm not sure why the _quaro.yml file cannot have the assets/ prefix for the location of the title-block.html for the build, but it appears that is the issue (note that the title-block.html does need to be in assets/ though).

I think @chrisroederucdenver made that modification to make a non-RStudio build process work, so this is likely to be specific to how we build in Rstudio (and how github actions builds for the page).

This PR also changes a setting in the .Rproj to cause RStudio to *not* auto-format markdown files on save, which was causing me all kinds of headaches as well and I think was the reason Chris was trying an alternative build process.