### PR TITLE
Striplvl1

### DIFF
--- a/chapters/access.md
+++ b/chapters/access.md
@@ -105,7 +105,7 @@ Level 1 data are no longer available. Previously, these data
 contained "synthetic" data generated via statistical processes to match specific
 aspects of the Level 3 data. We include this section here for historical context.
 
-#### Example N3C OMOP Data Format {#sec-access-background-l1-example}
+### Example N3C OMOP Data Format {#sec-access-background-l1-example}
 
 To give a sneak preview of the primary N3C data format,
 here's a snapshot of a few columns of notional (_fake_) data in OMOP format

--- a/chapters/access.md
+++ b/chapters/access.md
@@ -40,7 +40,8 @@ and publicly-available data (e.g., US census data) are accessible by everyone wi
 These low-risk data are covered more in Chapters [-@sec-understanding] and [-@sec-publishing].
 
 The harmonized EHR data that _do_ require an approved DUR to access
-are made available in three different "levels", each with different amounts of data obfuscation,
+are made available in two different "levels" (known as Level 2 and Level 3 
+for historical reasons--see below), each with different amounts of data obfuscation,
 and correspondingly different access requirements.
 Deciding which level of data is appropriate for your study is important,
 because accessing Level 3 data is more work and restrictive than accessing Level 2 data.
@@ -48,7 +49,7 @@ On the other hand, some studies can be accomplished with only Level 3 data.
 Note that if you start with a lower level of data, it is possible to "upgrade" a project's access level,
 though all participants in the project will need to complete another DUR for the new level.
 
-In addition to the primary Level 1, 2, and 3 datasets are "PPRL" data.
+In addition to the primary Level 2 and 3 datasets are "PPRL" data.
 PPRL data includes extra non-EHR sources of information
 such as obituary-based mortality records and viral variant sequencing information.
 These are available alongside only Level 3 data as an optional add-on;
@@ -98,50 +99,11 @@ Such questions are best answered by the LDS data.
 The Level 2 data are also in OMOP format and versioned as releases.
 We'll forgo examples of notional data because the format is exactly the same as for Level 3, LDS data.
 
-### Level 1, Synthetic {#sec-access-background-l1}
+### Level 1, (Synthetic, Deprecated) {#sec-access-background-l1}
 
-Level 1, or Synthetic,^[The Synthetic data discussed here
-should not be confused with the notional (fake) datasets described in @sec-publishing.
-These happen to have similar sounding names: SynPuf and Synthea.]
-data provide the most anonymous view of the harmonized data,
-and are quite different from the Level 2 and 3 datasets in both format and content.
-Rather, Level 1 data were _generated_ from a statistical model of a _researcher-defined subset_ of the Level 3 data.
-This means Level 1 data contain no real patient records at all,
-but only a synthetic derivative designed to be statistically similar.
-The generation process is handled by a private company, MDClone,
-whose proprietary algorithms also look for resulting information
-that is too similar to real patient information,
-potentially resulting in a loss of patient privacy.
-Such records are masked with "censored" values in the resulting dataset.
-
-Because this statistical-modeling approach doesn't scale to the entirety of an EHR database,
-it is generated on subsets of data of interest to researchers,
-with the assistance of MDClone representatives.
-To take an example, consider a research team interested in outcomes of COVID-19 in diabetic vs. non-diabetic individuals.
-Inside the Enclave, the team initiates a request with an MDClone liaison,
-suggesting that they would like to collect a set of patient information
-(with one row per patient in the resulting table),
-with columns for `patient_age`
-(at the date of their first COVID-positive PCR test result),
-`has_diabetes`
-(indicating if their record contains a diabetes diagnosis),
-`days_until_ventilation`
-(number of days elapsed between their COVID-positive test and subsequent mechanical ventilation,
-or `null` if they were not ventilated within 30 days),
-and several other potential confounding variables.
-The MDClone liaison then collects this requested information from the Level 3 data,
-develops a representative statistical model,
-and delivers a table of synthesized rows from the model with the columns requested to the team.
-
-Level 1 datasets are generated from the most recent Level 3 release at the time of generation,
-and not automatically updated as new primary N3C data arrives.
-Notes for each Level 1 dataset describe the date of generation and information included for future reference.
-
-::: {.callout-note appearance="simple" icon=true}
-Update: As of mid-2022, N3C is no longer able to generate new synthetic datasets at researcher request.
-The previously-generated datasets are still available for use however,
-and gaining access to Level 1 data provides access to all generated synthetic datasets.
-:::
+Level 1 data are no longer available. Previously, these data 
+contained "synthetic" data generated via statistical processes to match specific
+aspects of the Level 3 data. We include this section here for historical context.
 
 #### Example N3C OMOP Data Format {#sec-access-background-l1-example}
 
@@ -187,7 +149,7 @@ and the Introduction section of the
 [PPRL training module](https://unite.nih.gov/workspace/module/view/latest/ri.workshop.main.module.e7b83a8c-545e-49ac-8714-f34bfa7f7767?view=focus&Id=23) {{< fa lock title="Link requires an Enclave account" >}}
 in the Training Portal (see @sec-support-training).
 
-## Level 1/2/3 (and PPRL) Availability {#sec-access-availability}
+## Level 2/3 (and PPRL) Availability {#sec-access-availability}
 
 Level 3, LDS data are available only to researchers affiliated with US-based organizations such as universities and medical schools.
 As we'll discuss below, the most significant access requirement for Level 3 data
@@ -198,18 +160,6 @@ or IRB (e.g., pharmaceutical companies).
 
 Level 2, De-Identified data are available to researchers at both US and approved foreign organizations
 (those that can sign an institutional Data Use Agreement (DUA), see @sec-cycle).
-
-Level 1 Synthetic data are available to researchers at US and approved foreign organizations
-(though note the update about Level 1 data generation above),
-as well as individuals without any affiliation with a research organization,
-i.e., "citizen scientists".
-This level of data thus provides opportunities for public outreach and engagement with topics in clinical science.
-Citizen scientists must nevertheless complete some training requirements and sign the legal Data Use Agreement document.
-Minors may apply for access, but only via their parents' or legal guardians' consent and with explicit N3C consent.
-
-Since the registration process is non-trivial for those not affiliated with a research institution,
-citizen scientists hoping to work with Level 1 Synthetic data
-should reach out to one of the N3C support venues to get started (see @sec-support).
 
 PPRL data can be accessed alongside only Level 3 (LDS) data,
 and as such has the same access availability.
@@ -406,9 +356,9 @@ with the Level 1 data and return to see the differences for Levels 2 and 3.
 
 ![DUR data level request.](images/access/fig-access-090-dur-data-level.png){#fig-access-090-dur-data-level fig-alt="DUR data level request"}
 
-### Level 1 DUR Requirements {#sec-access-request-l1}
+### Base DUR Requirements {#sec-access-request-l1}
 
-For Level 1 access, the first requirements are that you have read
+For both level 2 and Level 3 access, the first requirements are that you have read
 and attested to the [Data Use Agreement](onboarding.md#data-use-agreements),
 and that you have completed the required NIH IT Security training course within the past year.
 Both of these are also required as part of onboarding,
@@ -416,7 +366,7 @@ so we won't cover them here (see @sec-onboarding).
 
 ![DUR attestations.](images/access/fig-access-100-dur-attestations.png){#fig-access-100-dur-attestations fig-alt="DUR attestations"}
 
-Finally, you will need to attest to having read the N3C Code of Conduct (with the text provided above),
+Next, you will need to attest to having read the N3C Code of Conduct (with the text provided above),
 that you have read and understood the [N3C download policy](publishing.md)
 (a link is provided via the more information icon),
 and that if you choose to use any additional data sources in connection with N3C protected data

--- a/chapters/governance.md
+++ b/chapters/governance.md
@@ -44,8 +44,7 @@ multiple commercial partners; and a large community of researchers.
 Four [co-leads](https://covid.cd2h.org/team) (two from the researcher community and two from NCATS) developed the vision for N3C and led its implementation with extensive community consultation.
 Their vision was to bridge the traditional silos of biomedical research to rapidly enable team science while respecting the rights of data subjects, institutions, and researchers.
 To accomplish this at record speed, the N3C leadership established five community [workstreams](https://covid.cd2h.org/n3c).
-Five Community workstreams were rapidly organized: Data Partnership & Governance, Phenotype & Data Acquisition, Data Ingestion & Harmonization, Collaborative Analytics, and Synthetic Data.
-focusing on specific N3C components.
+Five Community workstreams were rapidly organized: Data Partnership & Governance, Phenotype & Data Acquisition, Data Ingestion & Harmonization, Collaborative Analytics, and Synthetic Data, focusing on specific N3C components.
 The workstreams are supported by dedicated administrative staff, with virtual workspaces and communication channels (Slack) to share materials and reduce barriers to participation.
 The workstreams meet regularly, and meetings are open to anyone interested in participating or monitoring activities.
 Early on, the N3C conducted [general webinars](https://www.youtube.com/watch?v=O8dZAl9nSds&list=PLE4bNBEGV4OW6UBwCaJzurbQNFhz48TKn&index=7OW6UBwCaJzurbQNFhz48TKn) and Questions and Answers sessions to inform potential partners and created a Welcome Partnership Packet to help initiate participation.
@@ -96,7 +95,7 @@ Seven principles summarize the Community Guiding Principles:
 1. **Partnership**:
   N3C community members are trusted partners committed to honoring the [N3C community guiding principles](https://zenodo.org/record/3979610) and [N3C User Code of Conduct](https://ncats.nih.gov/n3c/resources/data-user-code-of-conduct)
 1. **Inclusivity**:
-  N3C is open to any organization that wishes to contribute data, code, and ideas, as well as anyone who registers to use N3C data to conduct COVID-19-related research, including citizen/community scientists
+  N3C is open to any organization that wishes to contribute data, code, and ideas, as well as anyone who registers to use N3C data to conduct COVID-19-related research.
 1. **Transparency**:
   Open processes and reproducible research is the hallmark of N3C and good scientific practice.
   Access to data is project-based and focused on COVID-19 research questions.

--- a/chapters/governance.md
+++ b/chapters/governance.md
@@ -150,10 +150,10 @@ Only then can users submit a Data Use Request (DUR).
 NCATS established a Data Access Committee (DAC) responsible for reviewing and approving DURs and addressing user questions.
 Users must submit a new DUR for every separate study. (See Chapters [-@sec-onboarding] and [-@sec-access] for details.)
 
-There are three levels of data access commensurate with the sensitivity of the data.
-See @sec-access for more details about these levels.
+There are two levels of data access commensurate with the sensitivity of the data (Level 1 is no longer available, 
+see @sec-access for more details about these levels.)
 
-![Data Tiers.](images/governance/fig-governance-020-tiers.png){#fig-governance-020-tiers fig-alt="Data Tiers"}
+![Data Tiers. Note that Level 1 data are deprecated.](images/governance/fig-governance-020-tiers.png){#fig-governance-020-tiers fig-alt="Data Tiers"}
 
 Access to each data level requires approval from the Data Access Committee.
 In addition, investigators requesting access to level 3 data must submit proof of IRB approval from their institution or an independent accredited IRB for their intended use.

--- a/chapters/intro.md
+++ b/chapters/intro.md
@@ -69,7 +69,7 @@ Once harmonized and stored in the secure "N3C Data Enclave", the data are made a
 
 Mere access to the Enclave, however, doesn't automatically provide access to any of the protected data itself (although we do make other, publicly-available datasets available with minimal restriction for practice and learning purposes).
 Multiple "levels" of the data are available with different anonymization techniques applied, facilitating "just enough" access to research teams depending on their needs and ability to access protected health information.
-Accessing the most secure level, for example, requires obtaining approval from an Institutional Review Board (IRB) which validates the appropriateness of human subjects research, while the lowest level is heavily anonymized and accessible by private individuals (citizen scientists) with only certain legal and training requirements.
+Accessing data will full patient zip codes, for example, requires obtaining approval from an Institutional Review Board (IRB) which validates the appropriateness of human subjects research, while access to de-identified data with truncated zip codes requires only having completed Human Subject Research Protection training at your local institution.
 
 Because effective analysis of EHR data requires a diverse set of skills-especially clinical and data science/statistical expertise-N3C provides organizational structures and resources to rapidly create and support multidisciplinary research teams, many of which are geographically diverse as well.
 As of February 2023, dozens of these "[Domain Teams](onboarding.md#sec-onboarding-dt)" have supported over 400 research projects, contributed to by over 3,300 researchers hailing from 350+ different institutions and organizations.

--- a/chapters/onboarding.md
+++ b/chapters/onboarding.md
@@ -44,19 +44,16 @@ There are several steps that need to be completed in order for a researcher or N
 
 ## Researcher Eligibility {#sec-onboarding-eligibility}
 
-Citizen scientists, researchers from foreign institutions, and researchers from U.S.-based institutions are all eligible to have access to the N3C Data Enclave.
+Researchers from both foreign and U.S.-based institutions are eligible to have access to the N3C Data Enclave.
 Everyone with an Enclave account has access to the tools and public [datasets](https://covid.cd2h.org/external-datasets) that are available in the Enclave.
 
-There are several levels of Electronic Health Record (EHR) data that are available within the Enclave.
+There are two levels of Electronic Health Record (EHR) data that are available within the Enclave, termed "Level 2" and "Level 3" for historical reasons.
 For more information about the levels of data, see @sec-access-background.
 
-If an individual is not affiliated with an institution, they are termed a "citizen scientist".   Citizen scientists are only eligible to access synthetic data (Level 1).
-This data set is artificial but statistically-comparable to, and computationally derived from, the original EHR data.
-
-Researchers from institutions outside the U.S. are eligible to access synthetic data (Level 1) and patient data that has been deidentified by removing protected health information (PHI) (Level 2).
+Researchers from institutions outside the U.S. are eligible to access patient data that has been de-identified by removing protected health information (PHI) (Level 2).
 Protected health information includes 18 elements defined by the Health Insurance Portability and Accountability Act (HIPAA). ^[A list of identifiers that the HIPAA Privacy Rule applies to is available on the U.S. Department of Health & Human Services website in the section [The second is the "Safe Harbor" method](https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html).]
 
-Researchers from U.S.-based institutions are eligible to access synthetic data (Level 1), deidentified patient data (Level 2), and patient data that includes dates of service and patient zip code (Level 3). (The Level 3 data set is referred to as a _limited_ dataset because it contains only 2 of the 18 PHI elements.) Here are the data access levels, eligibility, and access requirements.
+Researchers from U.S.-based institutions are eligible to access de-identified patient data (Level 2), and patient data that includes dates of service and patient zip code (Level 3). (The Level 3 data set is referred to as a _limited_ dataset because it contains only 2 of the 18 PHI elements.) Here are the data access levels, eligibility, and access requirements.
 
 ### Data Level 3 {#sec-onboarding-eligibility-l3}
 
@@ -104,23 +101,9 @@ Researchers from U.S.-based institutions are eligible to access synthetic data (
 
 ### Data Level 1 {#sec-onboarding-eligibility-l1}
 
-* _Also known as_:
-  * Synthetic Data Set
-
-* _Data Description_:
-  Data that are computationally derived from the LDS that resemble patient information statistically but are not actual patient data.
-
-* _Eligible Users_:
-  * Researchers from U.S.-based institutions
-  * Researchers from foreign institutions
-  * Citizen scientists
-
-* _Access Requirements_:
-  * N3C registration
-  * N3C Data Enclave account
-  * DUA executed with NCATS
-  * NIH IT training completion
-  * Approved DUR
+Level 1 data are no longer available. Previously, these data 
+contained "synthetic" data generated via statistical processes to match specific
+aspects of the Level 3 data. We include this section here for historical context.
 
 ## Program Registration {#sec-onboarding-program}
 
@@ -215,16 +198,18 @@ A data use agreement (DUA) establishes the permitted uses of the data in the N3C
 By signing the agreement, an institutional official is assuring that users from their institution will abide by the terms defined in the agreement.
 
 A DUA must be executed by the National Center for Advancing Translational Science (NCATS) and a research institution or private organization.
-The DUA must be signed by authorized officials who have the authority to bind all users at their organization to the terms of the DUA.  (A citizen scientist who is not affiliated with an institution must execute a DUA with NCATS individually in order to gain access to the Enclave.)  A DUA will be in effect for five years from the DUA Effective Date.
+The DUA must be signed by authorized officials who have the authority to bind all users at their organization to the terms of the DUA. A DUA will be in effect for five years from the DUA Effective Date.
 
 Every individual who has access to the Enclave must be covered by a DUA.
 This DUA must be in place before an account for the Enclave is requested.
 If your institution has an active DUA, there is no additional action required with regard to the DUA.
 A list of institutions with DUAs can be found at <https://covid.cd2h.org/duas>.
 
-The [Institutional DUA form](https://ncats.nih.gov/files/NCATS_N3C_Data_Use_Agreement.pdf) is available on the web.
-If your institution is not on the list, your Institution can submit a DUA to NCATS by emailing the completed form to <NCATSPartnerships@mail.nih.gov>.
-See <https://ncats.nih.gov/n3c/resources/data-access> for more information on access forms and resources.
+:::{.callout-warning}
+The original Data Use Agreement is set to expire in early 2025. Researchers wishing to continue access to N3C COVID data beyond 4/1/2025
+**must** have their institution sign the new N3C COVID Data Use Agreement *Extension*. More
+information and instructions can be found [here](https://covid.cd2h.org/covid-extension/).
+:::
 
 ## Research Project Teams {#sec-onboarding-team}
 

--- a/chapters/support.md
+++ b/chapters/support.md
@@ -225,7 +225,7 @@ Within this folder you will be able to create new analyses, and these will have 
 
 OMOP-formatted N3C patient data are protected by a [Data Use Request](access.md#sec-access-dur) process, but researchers may wish to explore OMOP tables and Enclave tools prior to completing a DUR.
 The N3C Training Area is the place to do such practice, and N3C provides two notional (i.e., fake) datasets formatted similarly to the [Level 2 and Level 3](access.md) data that do not require a DUR to access.
-They are both available via the [data catalog](access.md#sec-access-workspaces) under "Synpuf Synthetic Data" and "Synthea Notional Data".^[Note that these should not be confused with the [Level 1 Synthetic Data](access.md#sec-access-availability), which are derived from N3C patient data and protected by a Data Use Request.] The data they contain differ in some important ways, described next.
+They are both available via the [data catalog](access.md#sec-access-workspaces) under "Synpuf Synthetic Data" and "Synthea Notional Data". The data they contain differ in some important ways, described next.
 
 ![Two sets of synthetic data.](images/support/fig-support-190-synthetic-datasets.png){#fig-support-190-synthetic-datasets width=75% fig-alt="Two sets of synthetic data"}
 


### PR DESCRIPTION
Resolves #173 and #227 by removing mentions of citizen scientist access, level 1 data (except for stubs for historical context), and provides an update to the DUA section to link to the new DUA Extension that will be required in 2025.